### PR TITLE
Make active_zuora work for belly-operations

### DIFF
--- a/active_zuora.gemspec
+++ b/active_zuora.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [ "README.md" ]
 
   s.add_runtime_dependency('savon', ["~> 1.2.0"])
-  s.add_runtime_dependency('activesupport', [">= 3.0.0", "< 5.0.0"])
-  s.add_runtime_dependency('activemodel', [">= 3.0.0", "< 5.0.0"])
+  s.add_runtime_dependency('activesupport', [">= 3.0.0", "< 5.1.0"])
+  s.add_runtime_dependency('activemodel', [">= 3.0.0", "< 5.1.0"])
 
   s.add_development_dependency('rake', [">= 0.8.7"])
   s.add_development_dependency('rspec', [">= 3.0.0"])

--- a/active_zuora.gemspec
+++ b/active_zuora.gemspec
@@ -22,6 +22,9 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [ "README.md" ]
 
   s.add_runtime_dependency('savon', ["~> 1.2.0"])
+  # as of 2016-09-13, this deviates from the main gem repositoiry
+  # at https://github.com/sportngin/active_zuora
+  # it has been updated to allow ActiveRecord 5
   s.add_runtime_dependency('activesupport', [">= 3.0.0", "< 5.1.0"])
   s.add_runtime_dependency('activemodel', [">= 3.0.0", "< 5.1.0"])
 

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -197,6 +197,9 @@ module ActiveZuora
         include LazyAttr
         exclude_from_queries :overage_price, :included_units,
           :discount_amount, :discount_percentage, :rollover_balance
+        # as of 2016-09-13, this deviates from the main gem repositoiry
+        # at https://github.com/sportngin/active_zuora
+        # it has been updated to remove lazy loading of :price
       end
 
       customize 'Refund' do

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -196,8 +196,7 @@ module ActiveZuora
       customize 'RatePlanCharge' do
         include LazyAttr
         exclude_from_queries :overage_price, :included_units,
-          :discount_amount, :discount_percentage, :rollover_balance, :price
-        lazy_load :price
+          :discount_amount, :discount_percentage, :rollover_balance
       end
 
       customize 'Refund' do


### PR DESCRIPTION
There are a couple of issues in the current version of [active_zuora](https://github.com/sportngin/active_zuora), so I forked it. I hesitate to contribute either of these changes to the main fork (yet), since they're both untested and unproven.
1. Runtime dependency was pegged to ActiveRecord 4.2. That's not gonna work for us if we want to use Rails 5.
2. At some point, the main authors started lazy loading price on RatePlanCharge objects. This caused some specs to start failing for us because we recorded VCR cassettes with an old version of the gem. Removing the lazy load fixes the spec.

@bellycard/platform 
